### PR TITLE
set sample_ms as bigint instead int

### DIFF
--- a/Monitoring Scripts/Complete Server Monitoring.sql
+++ b/Monitoring Scripts/Complete Server Monitoring.sql
@@ -45,7 +45,7 @@ CREATE TABLE [dbo].[IO_VirtualFileStats](
 	[SampleDate] [datetime] NOT NULL,
 	[FileId] [smallint] NOT NULL,
 	[FileName] [sysname] NOT NULL,
-	[sample_ms] [int] NOT NULL,
+	[sample_ms] [bigint] NOT NULL,
 	[num_of_reads] [bigint] NOT NULL,
 	[num_of_bytes_read] [bigint] NOT NULL,
 	[io_stall_read_ms] [bigint] NOT NULL,


### PR DESCRIPTION
As `sys.dm_io_virtual_file_stats` is returning bigint for `sample_ms` having the column as int return the following error:
```Msg 8115, Level 16, State 2, Procedure CollectPerformanceData_IO, Line 6 [Batch Start Line 302]
Arithmetic overflow error converting expression to data type int.```

To avoid it I've set the column as bigint