### PR TITLE
Add SET ANSI_PADDING ON

### DIFF
--- a/Monitoring Scripts/CPU utilization (based on RING_BUFFER_SCHEDULER_MONITOR).sql
+++ b/Monitoring Scripts/CPU utilization (based on RING_BUFFER_SCHEDULER_MONITOR).sql
@@ -3,7 +3,7 @@ SET ANSI_PADDING ON;
 DECLARE @NumOfSamplesToCheck int = 10
 
 DECLARE @TimeStamp bigint
-SELECT @TimeStamp = cpu_ticks / (cpu_ticks/ms_ticks) FROM sys.dm_os_sys_info
+SELECT @TimeStamp = ms_ticks FROM sys.dm_os_sys_info
 
 SELECT
 	DATEADD (ms, -1 * (@TimeStamp - [timestamp]), GETDATE()) AS [SystemTime],

--- a/Monitoring Scripts/CPU utilization (based on RING_BUFFER_SCHEDULER_MONITOR).sql
+++ b/Monitoring Scripts/CPU utilization (based on RING_BUFFER_SCHEDULER_MONITOR).sql
@@ -1,4 +1,5 @@
 SET NOCOUNT ON;
+SET ANSI_PADDING ON;
 DECLARE @NumOfSamplesToCheck int = 10
 
 DECLARE @TimeStamp bigint


### PR DESCRIPTION
When the default ANSI_PADDING is OFF I got an error:
`SELECT failed because the following SET options have incorrect settings: 'ANSI_PADDING'. Verify that SET options are correct for use with indexed views and/or indexes on computed columns and/or filtered indexes and/or query notifications and/or XML data type methods and/or spatial index operations`

Added SET ANSI_PADDING ON to make sure we can run this query

ALSO - simplified the `@timestamp` variable creation